### PR TITLE
Drop soft margin

### DIFF
--- a/configs/codestyles/JUUL Labs.xml
+++ b/configs/codestyles/JUUL Labs.xml
@@ -1,6 +1,5 @@
 <code_scheme name="JUUL Labs" version="173">
-  <option name="SOFT_MARGINS" value="100" />
-  <option name="RIGHT_MARGIN" value="120" />
+  <option name="RIGHT_MARGIN" value="100" />
   <AndroidXmlCodeStyleSettings>
     <option name="USE_CUSTOM_SETTINGS" value="true" />
     <option name="LAYOUT_SETTINGS">

--- a/configs/codestyles/JUUL Labs.xml
+++ b/configs/codestyles/JUUL Labs.xml
@@ -1,6 +1,6 @@
 <code_scheme name="JUUL Labs" version="173">
-  <option name="RIGHT_MARGIN" value="100" />
-  <option name="SOFT_MARGINS" value="120" />
+  <option name="SOFT_MARGINS" value="100" />
+  <option name="RIGHT_MARGIN" value="120" />
   <AndroidXmlCodeStyleSettings>
     <option name="USE_CUSTOM_SETTINGS" value="true" />
     <option name="LAYOUT_SETTINGS">


### PR DESCRIPTION
Soft margin [wraps visually in the IDE](https://intellij-support.jetbrains.com/hc/en-us/community/posts/206020464-Code-runs-off-right-margin-before-wrapping) ([not in the saved file](https://intellij-support.jetbrains.com/hc/en-us/community/posts/207025985/comments/206895885)).

[Neither of Square's code styles includes soft margins](https://github.com/square/java-code-styles/tree/main/configs/codestyles), and I'd prefer not to soft wrap as well.